### PR TITLE
Fix missing ln for B in step 5.2

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,7 +237,7 @@ pub fn new_rating(
             let delta_squared = delta * delta;
             let rd_squared = prior_rating.deviation * prior_rating.deviation;
             let mut b = if delta_squared > rd_squared + v {
-                delta_squared - rd_squared - v
+                (delta_squared - rd_squared - v).ln()
             } else {
                 let mut k = 1.0;
                 while f(
@@ -281,7 +281,7 @@ pub fn new_rating(
                     sys_constant,
                 );
                 // b
-                if fc * fb < 0.0 {
+                if fc * fb <= 0.0 {
                     a = b;
                     fa = fb;
                 } else {


### PR DESCRIPTION
Looks like there is a mistake plus one slight deviation from the paper, that can sometimes cause the algorithm to loop forever.